### PR TITLE
Infer deb deps

### DIFF
--- a/files/control
+++ b/files/control
@@ -3,7 +3,7 @@ Version: VERSION()-BUILDNO()
 Section: development
 Priority: optional
 Architecture: all
-Depends: DEB_DEPS() libgmp10, libz1
+Depends: DEB_DEPS()
 Maintainer: Anchor Engineering <engineering@lists.anchor.net.au>
 Description:
 DEB_DESC()

--- a/files/getDebDeps.sh
+++ b/files/getDebDeps.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+ldd $1 | awk '/=>/{print $(NF-1)}' | sort -u | while read n; do dpkg -S $n; done | cut -d':' -f1 | sort -u

--- a/haskell2package.cabal
+++ b/haskell2package.cabal
@@ -1,5 +1,5 @@
 name:                haskell2package
-version:             1.2.0
+version:             1.3.0
 synopsis:            Builds .rpms and .debs from Haskell projects
 description:         Parses cabal files and generates a specfile or control file,
                      which is then used to build an rpm or deb respectively,

--- a/lib/Anchor/Package/Process.hs
+++ b/lib/Anchor/Package/Process.hs
@@ -57,7 +57,7 @@ packageDebian = do
             callProcess "cabal" ["build"]
             deps <- getSysDeps executablePaths
             control <- runReaderT generateControlFile packagerInfo{sysDeps=S.fromList deps}
-            let controlPath = target </> "debian/DEBIAN/control"
+            let controlPath = "debian/DEBIAN/control"
             writeFile controlPath control
             forM_ executablePaths
                 (\x -> callProcess "cp" [x, "debian/usr/bin/"])

--- a/lib/Anchor/Package/Process.hs
+++ b/lib/Anchor/Package/Process.hs
@@ -33,8 +33,6 @@ packageDebian = do
         let CabalInfo{..} = cabalInfo
         let executablePaths = map (\x -> "dist/build" </> x </> x) executableNames
         liftIO $ do
-            system "sudo apt-get install -y m4"
-
             createDirectoryIfMissing True $ workspacePath </> "packages"
             createDirectoryIfMissing True $ target </> "debian/usr/bin"
             createDirectoryIfMissing True $ target </> "debian/DEBIAN"

--- a/lib/Anchor/Package/Process.hs
+++ b/lib/Anchor/Package/Process.hs
@@ -120,8 +120,7 @@ genPackagerInfo = do
     return PackagerInfo{..}
   where
     strip = reverse . dropWhile isSpace . reverse . dropWhile isSpace
-    getAnchorRepos token =
-        S.fromList <$> either (error . show) (map repoName) <$> organizationRepos' (GithubOAuth <$> token) "anchor"
+    getAnchorRepos token = S.fromList <$> either (error . show) (map repoName) <$> organizationRepos' (GithubOAuth <$> token) "anchor"
     cloneAndFindDeps target anchorRepos = do
         startingDeps <- (\s -> s `S.difference` S.singleton target) <$>
                             findCabalBuildDeps (cabalPath target) anchorRepos

--- a/lib/Anchor/Package/Template.hs
+++ b/lib/Anchor/Package/Template.hs
@@ -5,6 +5,7 @@ module Anchor.Package.Template where
 import           Control.Arrow
 import           Control.Monad.IO.Class
 import           Control.Monad.Reader
+import           Data.List
 import           Data.Maybe
 import           Data.Monoid
 import qualified Data.Set               as S
@@ -50,7 +51,7 @@ generateM4 = do
             , ("ADD_SRCS",    generateSandboxStrings $ S.toList anchorDeps)
             , ("BUILD_REQS",  generateBuildReqs      $ S.toList sysDeps)
             , ("RUN_REQS",    generateRunReqs        $ S.toList sysDeps)
-            , ("DEB_DEPS",    concatMap (<> ",")     $ S.toList sysDeps)
+            , ("DEB_DEPS",    intercalate ","        $ S.toList sysDeps)
             , ("CHANGELOG_HEADING", changelogHeading)
             ]
     return $ unlines $ m4Header <> defines


### PR DESCRIPTION
Use ldd to infer system dependencies for .debs instead of passing them on command line